### PR TITLE
Added RailsCamp New England 2013!

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -17,6 +17,7 @@
 
     <ol id="events">
       <li><a href="#germany_13">Cologne, Germany 2013</a></li>
+      <li><a href="#new_england_13">Bryant Pond, Maine, USA 2013</a></li>
       <li><a href="#sydney_13">Sydney, Australia 2013</a></li>
     </ol>
 
@@ -36,6 +37,22 @@
       <dt>Website</dt>
       <dd>
         <p><a href="http://2013.railscamp.de">2013.railscamp.de</a></p>
+      </dd>
+    </dl>
+
+    <h2><a name="new_england_13"></a>Maine, USA 2013</h2>
+    <dl>
+      <dt>When</dt>
+      <dd>
+        <p>Starts Friday, September 27th, runs until Monday morning, 30th.</p>
+      </dd>
+      <dt>Where</dt>
+      <dd>
+        <p>At <a href="http://www.themainehouses.com/mountain_house/mountain_house.php">The Maine Mountain View House</a>, Bryant Pond, Maine, USA</p>
+      </dd>
+      <dt>Website</dt>
+      <dd>
+        <p><a href="https://guestlistapp.com/events/176736">guestlistapp.com</a></p>
       </dd>
     </dl>
 


### PR DESCRIPTION
RailsCamp New England 2013 being held in Bryant Pond once again. Thanks for letting me know that the site was up on Github @pat. 
