### PR TITLE
Railscampsouth updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Project Title
+
+This repository hosts the files that comprise the Rails Camp homepage.
+https://rails.camp
+
+## Environment Setup
+
+This project uses RBenv to manage the ruby version and Jekyll to compile the static pages.
+
+On OS X with BASH
+```
+brew update && brew install ruby-build rbenv # Installs rbenv and ruby-build
+echo 'eval "$(rbenv init -)' >> ~/.bash_profile # Adds rbenv to bash profile
+source ~/.bash_profile # Load the profile for the current session
+rbenv install 2.5.1
+gem install bundler -v 1.17.3
+rbenv rehash # Updates the bin stubs for the project
+bundle install
+```
+
+## Running the server locally
+
+```
+bundle exec jekyll serve
+```
+
+## Running the Tests
+
+No tests. YOLO. Please review your updates manually.
+
+## Contributing
+
+If you have access to this repo you can contribute.
+
+## Deploying the Code
+
+Code automatically deploys on merge to master.
+
+## Contributors
+
+[Tracked on Github](https://github.com/pat/railscamps.com/graphs/contributors)
+
+## License
+
+All rights reserved.

--- a/_includes/events/bandera.html
+++ b/_includes/events/bandera.html
@@ -1,0 +1,56 @@
+<!-- this is a template for future events -->
+<h2 id="us_april_2019">Bandera, TX, USA, April 2019</h2>
+<dl>
+  <dt>When</dt>
+  <dd>
+    <p>The evening of Friday, April 5th, 2019</p>
+    <p>until</p>
+    <p>The morning of Monday, April 8th, 2019</p>
+  </dd>
+  <dt>Where</dt>
+  <dd>
+    <p>At the <a href="http://www.twinelmranch.com/">Twin Elms Dude Ranch</a> in Bandera, Texas. Close to San Antonio.</p>
+  </dd>
+  <dt>Can I Come?</dt>
+  <dd>
+    <p>Absolutely. Everyone is welcome. <a href="https://ti.to/railscamp-usa/rails-camp-south-2019">Buy a ticket!</a></p>
+  </dd>
+  <dt>Opportunity Tickets</dt>
+  <dd>
+    <p>
+      Depending on how many scholarship sponsors and applicants we receive we'll either be able to help pay for your whole ticket or just a portion of it. Apply regardless and we'll keep you posted.
+      <a href="https://us-south.rails.camp/opportunity-tickets/">Apply now!</a>
+    </p>
+  </dd>
+  <dt>Temperatures</dt>
+  <dd>
+      <div>
+          <p>April temps in Bandera range in:</p>
+          <p>82° - 60°F (Americans)</p>
+          <p>27° - 15°C (Everyone else)</p>
+      </div>
+  </dd>
+  <dt>What to Bring</dt>
+  <dd>
+    <ul>
+      <li>Light clothes</li>
+      <li>Laptop</li>
+      <li>Camera</li>
+      <li>Chargers</li>
+      <li>Toothbrush & Toiletries</li>
+      <li>Towel</li>
+      <li>Sleeping Bag</li>
+      <li>Earplugs</li>
+      <li>Pillow and Pillow case</li>
+      <li>Pillowcase</li>
+      <li>Medications</li>
+      <li>Libations</li>
+      <li>Snacks</li>
+      <li>Anything you can't get offline (download in advance)</li>
+    </ul>
+  </dd>
+  <dt>More Information</dt>
+  <dd>
+    <p>See <a href="https://us-south.rails.camp/">https://us-south.rails.camp/</a> for more details.</p>
+  </dd>
+</dl>

--- a/_includes/previous.html
+++ b/_includes/previous.html
@@ -25,7 +25,7 @@
   <dt id="usa_may_2018">Georgia, USA, May 2018</dt>
   <dd>
     <ul>
-      <li class="first">At the Wahsega 4-H Center in Dahlonega, Georgia.</li>
+      <li class="first">At the <a href="http://georgia4h.org/4-h-centers/wahsega-4-h-center/">Wahsega 4-H Center</a> in Dahlonega, Georgia.</li>
     </ul>
   </dd>
 

--- a/css/screen.css
+++ b/css/screen.css
@@ -68,8 +68,8 @@ h2 {
   color: #2F96D4;
 }
 
-#home dd p, #home ul {
-  margin-top: -1.45em; /* 12.5px */
+#home dd {
+  margin-top: -2em
 }
 
 #home p, #home ul {
@@ -78,13 +78,13 @@ h2 {
 }
 
 #home dd ul {
-  
+
 }
 #home dd ul li {
   display: inline;
   padding-left: 12px;
   padding-right: 2px;
-  background: transparent url(../images/dot.png) no-repeat 0 0.3em;
+  background: transparent url(../images/dot.png) no-repeat 0 0.5em;
 }
 #home dd ul li.first {
   padding-left: 0;

--- a/index.html
+++ b/index.html
@@ -2,19 +2,17 @@
 layout: default
 ---
 
-<!--
+
 <h2>Upcoming Events?</h2>
 
 <ol id="events">
-  <li><a href="#au_may_2019">Australia, Woodman Point (Perth, WA), May 2019</a></li>
+  <li><a href="#us_april_2019">Bandera, TX, USA, April 2019</a></li>
+  <!-- <li><a href="#au_may_2019">Australia, Woodman Point (Perth, WA), May 2019</a></li> -->
 </ol>
--->
 
 <p class="placeholder">Rails Camps are becoming regular fixtures in countries like Australia, New Zealand, UK, USA, Denmark and Poland. It would be awesome to see more happen elsewhere. Rails Camps happen because people make them happen. People like you.</p>
 
-<!--
-{% include events/perth.html %}
--->
+{% include events/bandera.html %}
 
 {% include previous.html %}
 


### PR DESCRIPTION
### Changes
- Added Rails Camp South 2019 event
- Brought back the upcoming events section
- Updated style for dl/dd/dt to be more specific toward intent of aligning dd/dt sections
- Added README on getting started

### Screenshot
<img width="1007" alt="screen shot 2019-01-08 at 1 24 14 pm" src="https://user-images.githubusercontent.com/1013461/50850920-4e608700-1349-11e9-8f53-8c75161b336e.png">
<br />
<hr />
<br />
<img width="947" alt="screen shot 2019-01-08 at 1 28 07 pm" src="https://user-images.githubusercontent.com/1013461/50850919-4e608700-1349-11e9-8dba-58e2276b99bf.png">

